### PR TITLE
Adding pcap file download button to RecentCalls view

### DIFF
--- a/src/pages/account/recent-calls/index.js
+++ b/src/pages/account/recent-calls/index.js
@@ -52,6 +52,72 @@ const StyledInputGroup = styled(InputGroup)`
   }
 `;
 
+const StyledPcapLink = styled.a`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  outline: 0;
+  height: 36px;
+  padding: 10px 26px 8px;
+  border-radius: 0.25rem;
+  background: #D91C5C;
+  color: #FFF;
+  text-decoration: none;
+
+  &:hover {
+    color: #FFF;
+    background: #BD164E;
+  }
+`;
+
+const PcapButton = ({call_data, account_sid, jwt_token}) => {
+  const [pcap, setPcap] = useState(null);
+
+  useEffect(() => {
+    axios({
+      method: "get",
+      baseURL: process.env.REACT_APP_API_BASE_URL,
+      url: `/Accounts/${account_sid}/RecentCalls/${call_data.sip_callid}`,
+      headers: {
+        Authorization: `Bearer ${jwt_token}`,
+      },
+    }).then((result_1) => {
+      if (result_1.status === 200 && result_1.data.total > 0) {
+        axios({
+          method: "get",
+          baseURL: process.env.REACT_APP_API_BASE_URL,
+          url: `/Accounts/${account_sid}/RecentCalls/${call_data.sip_callid}/pcap`,
+          headers: {
+            Authorization: `Bearer ${jwt_token}`,
+          },
+          responseType: "blob",
+        }).then((result_2) => {
+          setPcap({
+            dataUrl: URL.createObjectURL(result_2.data),
+            fileName: `callid-${call_data.sip_callid}.pcap`,
+          });
+        });
+      }
+    });
+  }, [call_data, account_sid, jwt_token, setPcap]);
+
+  if (pcap) {
+    return (
+      <Label>
+        <StyledPcapLink
+          href={pcap.dataUrl}
+          download={pcap.fileName}
+        >
+          Download pcap
+        </StyledPcapLink>
+      </Label>
+    );
+  }
+
+  return null;
+};
+
 const RecentCallsIndex = () => {
   const { width } = useContext(ResponsiveContext);
   let history = useHistory();
@@ -240,6 +306,7 @@ const RecentCallsIndex = () => {
             </React.Fragment>
           );
         })}
+        <PcapButton call_data={data} account_sid={account_sid} jwt_token={jwt} />
       </ExpandedSection>
     );
   };


### PR DESCRIPTION
Very important part of this PR is that we're specifying `responseType: "blob"` for Axios options on the `pcap` API endpoint so that the `Blob` parsed and returned by Axios works with `URL.createObjectURL`.

Wireshark screenshot from importing the downloaded file:

<img width="751" alt="Screen Shot 2021-08-01 at 9 51 32 AM" src="https://user-images.githubusercontent.com/438711/127779131-2b92c7fc-8a77-4f45-b787-9d0c5e8811f1.png">

