### PR TITLE
Delete SIP Gateway from Carrier when using Trash icon

### DIFF
--- a/src/pages/account/carriers/add-edit.js
+++ b/src/pages/account/carriers/add-edit.js
@@ -583,9 +583,32 @@ const CarriersAddEdit = ({ mode }) => {
   };
 
   const removeSipGateway = index => {
-    const newSipGateways = sipGateways.filter((s,i) => i !== index);
-    setSipGateways(newSipGateways);
-    setErrorMessage('');
+    if (sipGateways.length > 1) {
+      const newSipGateways = sipGateways.filter((s,i) => i !== index);
+      setSipGateways(newSipGateways);
+      setErrorMessage('');
+
+      axios({
+        method: 'delete',
+        baseURL: process.env.REACT_APP_API_BASE_URL,
+        url: `/SipGateways/${sipGateways[index].sip_gateway_sid}`,
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+        },
+      }).then(() => {
+        dispatch({
+          type: 'ADD',
+          level: 'success',
+          message: 'SIP Gateway Deleted Successfully'
+        });
+      });
+    } else {
+      dispatch({
+        type: 'ADD',
+        level: 'error',
+        message: 'You must retain at least one SIP Gateway'
+      });
+    }
   };
 
   const removeSmppGateway = index => {


### PR DESCRIPTION
Fixes the bug for this *hosted* version which was reported as an issue on the *open source* version here:
https://github.com/jambonz/jambonz-webapp/issues/26

This PR updates the code to make `DELETE` requests to `/SipGateways/{SipGatewaySid}` when using the Trash icon to "remove" an inbound/outbound SIP gateway from a Carrier form. The code has a condition to check the total number of SIP gateways such that you may *not* delete if there is only *one* SIP gateway left. The screenshot shows the alert notification when attempting to delete the last SIP gateway for a Carrier.

<img width="1222" alt="Screen Shot 2021-10-05 at 3 42 08 PM" src="https://user-images.githubusercontent.com/438711/136112968-8e8070ff-4694-4964-b59d-050266718440.png">


